### PR TITLE
CIDR parsing changed

### DIFF
--- a/classes/Leth/IPAddress/IP/Impl/NetworkAddress.php
+++ b/classes/Leth/IPAddress/IP/Impl/NetworkAddress.php
@@ -85,14 +85,14 @@ abstract class NetworkAddress implements \IteratorAggregate, \Countable
 			return $address;
 		}
 
-		if ($cidr === NULL)
-		{
-			$parts = explode('/', $address, 2);
-
-			if (count($parts) != 2)
-				throw new \InvalidArgumentException("Missing CIDR notation on '$address'.");
-
-			list($address, $cidr) = $parts;
+		$parts = explode('/', $address, 2);
+		if (count($parts) == 2) {
+			if ($cidr == NULL)
+				// Parse CIDR from $address variable because $cidr is null
+				list($address, $cidr) = $parts;
+			else
+				// Ignore CIDR into $address variable
+				list($address) = $parts;
 		}
 
 		if (is_string($cidr))
@@ -139,6 +139,10 @@ abstract class NetworkAddress implements \IteratorAggregate, \Countable
 	 */
 	protected function __construct(IP\Address $address, $cidr)
 	{
+		// Default CIDR equal single host
+		if ($cidr === NULL) {
+			$cidr = static::MAX_SUBNET;
+		}
 		if ( ! is_int($cidr) OR $cidr < 0 OR $cidr > static::MAX_SUBNET)
 			throw new \InvalidArgumentException("Invalid CIDR '.$cidr'.Invalid type or out of range for class ".get_class($this).".");
 

--- a/tests/IPNetworkAddressTest.php
+++ b/tests/IPNetworkAddressTest.php
@@ -100,21 +100,25 @@ class IP_NetworkAddress_Test extends PHPUnit_Framework_TestCase
 		IP\NetworkAddress::factory($address, $cidr);
 	}
 
-	public function providerFactoryException()
+	public function provideFactoryParseCIDR()
 	{
 		return array(
-			array('127.0.0.1/16', 16),
-			array('127.0.0.1', NULL),
+			array('127.0.0.1/16', 24, 24),
+			array('127.0.0.1', NULL, 32),
+			array('127.0.0.1/24', NULL, 24),
+			array('::1', NULL, 128),
+			array('::1/58', 64, 64),
+			array('::1/58', NULL, 58),
 		);
 	}
 
 	/**
-	 * @expectedException \InvalidArgumentException
-	 * @dataProvider providerFactoryException
+	 * @dataProvider provideFactoryParseCIDR
 	 */
-	public function testFactoryException($address, $cidr)
+	public function testParseCIDR($address, $cidr, $expected)
 	{
-		IP\NetworkAddress::factory($address, $cidr);
+		$network = IP\NetworkAddress::factory($address, $cidr);
+		$this->assertEquals($expected, $network->get_cidr());
 	}
 
 	public function providerUnimplementedException()


### PR DESCRIPTION
Usually if cidr not specified is considered to be what it is single host. Single host users in my project presented as x.x.x.x without cidr. I think what this is normal. I modified behavior factory method in NetworkAddress and its tests.
I removed the exception if address string contain cidr and $cidr variable is not empty. Now $cidr variable has higher priority than cidr in address string.