### PR TITLE
Update Math_BigInteger package to 1.0.3 to fix deprecation notice in …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 7.0
   - 5.6
   - 5.5
   - 5.4

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"issues": "https://github.com/leth/PHP-IPAddress/issues"
 	},
 	"require": {
-		"pear/math_biginteger": "1.0.2"
+		"pear/math_biginteger": "1.0.3"
 	},
 	"autoload": {
 		"psr-0": {


### PR DESCRIPTION
Very minor change - I recently had a PR merged to fix a deprecation notice in Math_BigInteger, just updating the composer.json for this package to use the new version.

Does not change any functionality, just fixes the notice if using PHP7.