### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,27 @@
 language: php
 php:
+  - 7.3
+  - 7.2
+  - 7.1
   - 7.0
   - 5.6
-  - 5.5
-  - 5.4
-  - 5.3
-  - hhvm
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
+
 env:
   - MATH_BIGINTEGER_MODE=INTERNAL
   - MATH_BIGINTEGER_MODE=GMP
   - MATH_BIGINTEGER_MODE=BCMATH
-matrix:
-  exclude:
-    # HHVM doesn't seem to have gmp functions.
-    - php: hhvm
-      env: MATH_BIGINTEGER_MODE=GMP
 
 before_script:
-  - composer install --dev
+  - composer install
 
 script:
-  - phpunit --configuration phpunit.xml.dist --coverage-text
+  - vendor/bin/phpunit --configuration phpunit.xml.dist --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,12 @@
 	"require": {
 		"pear/math_biginteger": "1.0.3"
 	},
+	"require-dev": {
+		"phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+	},
 	"autoload": {
-		"psr-0": {
-			"Leth\\IPAddress": "classes/"
+		"psr-4": {
+			"Leth\\IPAddress\\": "classes/Leth/IPAddress"
 		}
 	}
 }

--- a/tests/IPAddressTest.php
+++ b/tests/IPAddressTest.php
@@ -1,5 +1,6 @@
 <?php
 use Leth\IPAddress\IP, Leth\IPAddress\IPv4, Leth\IPAddress\IPv6;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for the IP\Address Class
@@ -7,7 +8,7 @@ use Leth\IPAddress\IP, Leth\IPAddress\IPv4, Leth\IPAddress\IPv6;
  * @package default
  * @author Marcus Cobden
  */
-class IP_Address_Test extends PHPUnit_Framework_TestCase
+class IP_Address_Test extends TestCase
 {
 
 	public function providerFactory()

--- a/tests/IPNetworkAddressTest.php
+++ b/tests/IPNetworkAddressTest.php
@@ -1,5 +1,6 @@
 <?php
 use Leth\IPAddress\IP, Leth\IPAddress\IPv4, Leth\IPAddress\IPv6;
+use PHPUnit\Framework\TestCase;
 
 class IP_Address_Tester extends IP\Address
 {
@@ -55,7 +56,7 @@ class IPv6_NetworkAddress_Tester extends IPv6\NetworkAddress
  * @package default
  * @author Marcus Cobden
  */
-class IP_NetworkAddress_Test extends PHPUnit_Framework_TestCase
+class IP_NetworkAddress_Test extends TestCase
 {
 	public function providerFactory()
 	{

--- a/tests/IPv4AddressTest.php
+++ b/tests/IPv4AddressTest.php
@@ -1,5 +1,6 @@
 <?php
-use Leth\IPAddress\IP, Leth\IPAddress\IPv4, Leth\IPAddress\IPv6;
+use Leth\IPAddress\IPv4, Leth\IPAddress\IPv6;
+use PHPUnit\Framework\TestCase;
 
 class Testing_IPv4_Address extends IPv4\Address
 {
@@ -15,7 +16,7 @@ class Testing_IPv4_Address extends IPv4\Address
  * @package default
  * @author Marcus Cobden
  */
-class IPv4_Address_Test extends PHPUnit_Framework_TestCase
+class IPv4_Address_Test extends TestCase
 {
 
 	public function providerFactory()
@@ -45,7 +46,7 @@ class IPv4_Address_Test extends PHPUnit_Framework_TestCase
 		$this->assertNotNull($instance);
 		$this->assertEquals($expected, (string) $instance);
 	}
-	
+
 	public function providerFactoryException()
 	{
 		return array(
@@ -67,7 +68,7 @@ class IPv4_Address_Test extends PHPUnit_Framework_TestCase
 		$ip = IPv4\Address::factory('127.0.0.1');
 		$this->assertEquals(2130706433, $ip->format(IPv4\Address::FORMAT_INTEGER));
 	}
-	
+
 	public function providerFormatException()
 	{
 		$bad_mode = -1;
@@ -108,7 +109,7 @@ class IPv4_Address_Test extends PHPUnit_Framework_TestCase
 			array('0.0.0.0', '0.0.0.0', '0.0.0.0', '0.0.0.0', '0.0.0.0', '255.255.255.255'),
 		);
 	}
-	
+
 	/**
 	 * @dataProvider providerBitwise
 	 */
@@ -116,13 +117,13 @@ class IPv4_Address_Test extends PHPUnit_Framework_TestCase
 	{
 		$ip1 = IPv4\Address::factory($ip1);
 		$ip2 = IPv4\Address::factory($ip2);
-		
+
 		$this->assertEquals($ex_and, (string) $ip1->bitwise_and($ip2));
 		$this->assertEquals($ex_or , (string) $ip1->bitwise_or($ip2));
 		$this->assertEquals($ex_xor, (string) $ip1->bitwise_xor($ip2));
 		$this->assertEquals($ex_not, (string) $ip1->bitwise_not());
 	}
-	
+
 	// TODO Check this
 	// public function providerAsIPv6Address()
 	// {
@@ -130,14 +131,14 @@ class IPv4_Address_Test extends PHPUnit_Framework_TestCase
 	// 		array('127.0.0.1', '0000:0000:0000:ffff:0127:0000:0000:0001'),
 	// 	);
 	// }
-	// 
+	//
 	// /**
 	//  * @dataProvider providerAsIPv6Address
 	//  */
 	// public function testAsIPv6Address($v4, $v6)
 	// {
 	// 	$ip = IPv4\Address::factory($v4);
-	// 	
+	//
 	// 	$this->assertEquals($v6, (string) $ip->asIPv6Address());
 	// }
 
@@ -160,12 +161,12 @@ class IPv4_Address_Test extends PHPUnit_Framework_TestCase
 			array('255.0.255.0', 257, '255.1.0.1'),
 			array('192.168.0.0', 4, '192.168.0.4'),
 		);
-		
-		for ($i=0; $i < count($data); $i++) { 
+
+		for ($i=0; $i < count($data); $i++) {
 			$data[$i][0] = IPv4\Address::factory($data[$i][0]);
 			$data[$i][2] = IPv4\Address::factory($data[$i][2]);
 		}
-		
+
 		return $data;
 	}
 
@@ -223,7 +224,7 @@ class IPv4_Address_Test extends PHPUnit_Framework_TestCase
 		$this->assertEquals(30, $ip->get_octet(2));
 		$this->assertEquals(40, $ip->get_octet(3));
 
-		$this->assertEquals(NULL, $ip->get_octet(4));
+		$this->assertNull($ip->get_octet(4));
 	}
 
 	public function testArrayAccess()
@@ -231,9 +232,9 @@ class IPv4_Address_Test extends PHPUnit_Framework_TestCase
 		$ip = IPv4\Address::factory('10.250.30.40');
 		$this->assertEquals(10, $ip[-4]);
 		$this->assertEquals(250, $ip[1]);
-		$this->assertTrue(isset($ip[1]));
+		$this->assertNotEmpty($ip[1]);
 
-		$this->assertEquals(NULL, $ip[4]);
+		$this->assertNull($ip[4]);
 		$this->assertFalse(isset($ip[4]));
 	}
 

--- a/tests/IPv4NetworkAddressTest.php
+++ b/tests/IPv4NetworkAddressTest.php
@@ -1,5 +1,6 @@
 <?php
-use Leth\IPAddress\IP, Leth\IPAddress\IPv4, Leth\IPAddress\IPv6;
+use Leth\IPAddress\IPv4;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for the IPv4\NetworkAddress Class
@@ -7,7 +8,7 @@ use Leth\IPAddress\IP, Leth\IPAddress\IPv4, Leth\IPAddress\IPv6;
  * @package default
  * @author Marcus Cobden
  */
-class IPv4_NetworkAddress_Test extends PHPUnit_Framework_TestCase
+class IPv4_NetworkAddress_Test extends TestCase
 {
 
 	public function providerSubnet()
@@ -47,28 +48,28 @@ class IPv4_NetworkAddress_Test extends PHPUnit_Framework_TestCase
 			array( 1, '128.000.000.000', 2147483648, '128 A'),
 			array( 0, '000.000.000.000', 4294967296, '256 A'),
 		);
-		
+
 		// Collapse redundant 0s
-		for ($i=0; $i < count($data); $i++) { 
+		for ($i=0; $i < count($data); $i++) {
 			$data[$i][1] = str_replace('00','0', $data[$i][1]);
 			$data[$i][1] = str_replace('00','0', $data[$i][1]);
 		}
-		
+
 		return $data;
 	}
-	
+
 	/**
 	 * @dataProvider providerSubnet
 	 */
 	public function testSubnets($cidr, $subnet, $address_count, $network_class)
 	{
 		$net = IPv4\NetworkAddress::factory('0.0.0.0', $cidr);
-		
+
 		$this->assertEquals($subnet, (string) $net->get_subnet_mask());
 		$this->assertEquals($address_count, $net->get_NetworkAddress_count());
 		$this->assertEquals($network_class, $net->get_network_class());
 	}
-	
+
 	public function testGlobalNetmask()
 	{
 		$this->assertEquals('255.255.255.255', (string) IPv4\NetworkAddress::get_global_netmask());
@@ -166,7 +167,7 @@ class IPv4_NetworkAddress_Test extends PHPUnit_Framework_TestCase
 	public function testCountableInterface()
 	{
 		$block = IPv4\NetworkAddress::factory('192.168.0.0/30');
-		$this->assertEquals(4, count($block));
+		$this->assertCount(4, $block);
 		$block = IPv4\NetworkAddress::factory('192.168.0.0/24');
 		$this->assertEquals(pow(2, 8), count($block));
 		$block = IPv4\NetworkAddress::factory('192.168.0.0/16');

--- a/tests/IPv6AddressTest.php
+++ b/tests/IPv6AddressTest.php
@@ -1,5 +1,6 @@
 <?php
-use Leth\IPAddress\IP, Leth\IPAddress\IPv4, Leth\IPAddress\IPv6;
+use Leth\IPAddress\IP, Leth\IPAddress\IPv6;
+use PHPUnit\Framework\TestCase;
 
 class TestingIPv6_Address extends IPv6\Address
 {
@@ -7,7 +8,7 @@ class TestingIPv6_Address extends IPv6\Address
 	{
 		return new TestingIPv6_Address($address);
 	}
-	
+
 	public function call_bitwise_operation($flag, IP\Address $other = NULL)
 	{
 		$this->bitwise_operation($flag, $other);
@@ -20,7 +21,7 @@ class TestingIPv6_Address extends IPv6\Address
  * @package default
  * @author Marcus Cobden
  */
-class IPv6_Address_Test extends PHPUnit_Framework_TestCase
+class IPv6_Address_Test extends TestCase
 {
 
 	public function providerFactory()
@@ -251,7 +252,7 @@ class IPv6_Address_Test extends PHPUnit_Framework_TestCase
 		$this->assertEquals(0x10, $ip->get_octet(10));
 		$this->assertEquals(0xFE, $ip->get_octet(15));
 
-		$this->assertEquals(NULL, $ip->get_octet(16));
+		$this->assertNull($ip->get_octet(16));
 	}
 
 	public function testMappedIPv4()
@@ -268,7 +269,7 @@ class IPv6_Address_Test extends PHPUnit_Framework_TestCase
 		$mappedIPv4Address = IP\Address::factory($mappedIPv4String);
 		$ordinaryIPv6Address = IP\Address::factory($ordinaryIPv6String);
 		$this->assertEquals($mappedIPv4Address->format(IPv6\Address::FORMAT_MAY_MAPPED_COMPACT), $mappedIPv4String);
-		$this->assertEquals($ordinaryIPv6Address->format(IPv6\Address::FORMAT_MAY_MAPPED_COMPACT), $ordinaryIPv6String);		
+		$this->assertEquals($ordinaryIPv6Address->format(IPv6\Address::FORMAT_MAY_MAPPED_COMPACT), $ordinaryIPv6String);
 	}
 
 	public function testArrayAccess()
@@ -277,7 +278,7 @@ class IPv6_Address_Test extends PHPUnit_Framework_TestCase
 		$this->assertEquals(0x12, $ip[-10]);
 		$this->assertEquals(0x10, $ip[10]);
 
-		$this->assertEquals(NULL, $ip[16]);
+		$this->assertNull($ip[16]);
 	}
 
 	/**

--- a/tests/IPv6NetworkAddressTest.php
+++ b/tests/IPv6NetworkAddressTest.php
@@ -1,5 +1,6 @@
 <?php
-use Leth\IPAddress\IP, Leth\IPAddress\IPv4, Leth\IPAddress\IPv6;
+use Leth\IPAddress\IPv6;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for the IP\NetworkAddress Class
@@ -7,7 +8,7 @@ use Leth\IPAddress\IP, Leth\IPAddress\IPv4, Leth\IPAddress\IPv6;
  * @package default
  * @author Marcus Cobden
  */
-class IPv6_NetworkAddress_Test extends PHPUnit_Framework_TestCase
+class IPv6_NetworkAddress_Test extends TestCase
 {
 	public function test_global_netmask()
 	{


### PR DESCRIPTION
# Changed log
- Let the `php-5.3` tests executing on `precise` dist.
Let `php-5.4` and `php-5.5` executing on `trusty` dist.
- Since the `php-7.x` versions are released, it's time to remove `hhvm` test.
- To avoid pre-built `PHPUnit` versions on Travis CI build has the unexpected error, using the `vendor/bin/phpunit` version instead.
- To let the tests be compatible with future stable `PHPUnit` version, using the `PHPUnit\Framework\TestCase` namespace instead.
- Defining multiple `PHPUnit` versions to support multiple different PHP versions.
- Removing additional white spaces.
- Removing the `--dev` option.
This option is deprecated when the composer does `install` command on project root folder.
The deprecated warning message is as follows:

```
You are using the deprecated option "dev". Dev packages are installed by default now.
```