### PR TITLE
Add php-7.4 on Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 7.4
   - 7.3
   - 7.2
   - 7.1


### PR DESCRIPTION
# Changed log
- Add `php-7.4` during Travis CI build because this PHP version is stable and it has been released.