### PR TITLE
PHP 8.1 Compatibility Fixes for Leth\IPAddress Library

### DIFF
--- a/classes/Leth/IPAddress/IP/Address.php
+++ b/classes/Leth/IPAddress/IP/Address.php
@@ -194,7 +194,7 @@ abstract class Address implements \ArrayAccess
 	 * @param integer $offset
 	 * @return boolean 
 	 */
-	public function offsetExists($offset)
+	public function offsetExists($offset): bool
 	{
 		return ($this->get_octet($offset) != NULL);
 	}
@@ -203,9 +203,9 @@ abstract class Address implements \ArrayAccess
 	 * Get the octet value from index
 	 *
 	 * @param integer $offset
-	 * @return integer 
+	 * @return mixed
 	 */
-	public function offsetGet($offset)
+	public function offsetGet($offset): mixed
 	{
 		return $this->get_octet($offset);
 	}
@@ -216,8 +216,10 @@ abstract class Address implements \ArrayAccess
 	 * @param integer $offset
 	 * @param mixed $value
 	 * @throws \LogicException
+     *
+     * @return void
 	 */
-	public function offsetSet($offset, $value)
+	public function offsetSet($offset, $value): void
 	{
 		throw new \LogicException('Operation unsupported');
 	}
@@ -227,8 +229,10 @@ abstract class Address implements \ArrayAccess
 	 *
 	 * @param integer $offset
 	 * @throws \LogicException
+     *
+     * @return void
 	 */
-	public function offsetUnset($offset)
+	public function offsetUnset($offset): void
 	{
 		throw new \LogicException('Operation unsupported');
 	}

--- a/classes/Leth/IPAddress/IP/Address.php
+++ b/classes/Leth/IPAddress/IP/Address.php
@@ -191,10 +191,10 @@ abstract class Address implements \ArrayAccess
 	/**
 	 * Whether octet index in allowed range
 	 *
-	 * @param integer $offset
+	 * @param mixed $offset
 	 * @return boolean 
 	 */
-	public function offsetExists($offset): bool
+	public function offsetExists(mixed $offset): bool
 	{
 		return ($this->get_octet($offset) != NULL);
 	}
@@ -202,10 +202,10 @@ abstract class Address implements \ArrayAccess
 	/**
 	 * Get the octet value from index
 	 *
-	 * @param integer $offset
+	 * @param mixed $offset
 	 * @return mixed
 	 */
-	public function offsetGet($offset): mixed
+	public function offsetGet(mixed $offset): mixed
 	{
 		return $this->get_octet($offset);
 	}
@@ -213,13 +213,13 @@ abstract class Address implements \ArrayAccess
 	/**
 	 * Operation unsupported
 	 *
-	 * @param integer $offset
+	 * @param mixed $offset
 	 * @param mixed $value
 	 * @throws \LogicException
      *
      * @return void
 	 */
-	public function offsetSet($offset, $value): void
+	public function offsetSet(mixed $offset, mixed $value): void
 	{
 		throw new \LogicException('Operation unsupported');
 	}
@@ -227,12 +227,12 @@ abstract class Address implements \ArrayAccess
 	/**
 	 * Operation unsupported
 	 *
-	 * @param integer $offset
+	 * @param mixed $offset
 	 * @throws \LogicException
      *
      * @return void
 	 */
-	public function offsetUnset($offset): void
+	public function offsetUnset(mixed $offset): void
 	{
 		throw new \LogicException('Operation unsupported');
 	}

--- a/classes/Leth/IPAddress/IP/NetworkAddress.php
+++ b/classes/Leth/IPAddress/IP/NetworkAddress.php
@@ -17,7 +17,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 namespace Leth\IPAddress\IP;
-use \Leth\IPAddress\IP, \Leth\IPAddress\IPv4, \Leth\IPAddress\IPv6;
+use \Leth\IPAddress\IP, \Leth\IPAddress\IPv4, \Leth\IPAddress\IPv6, \Traversable;
 
 /**
  * An abstract representation of an IP Address in a given network
@@ -565,9 +565,9 @@ abstract class NetworkAddress implements \IteratorAggregate, \Countable
 	 * Get iterator for this network
 	 * Implement \IteratorAggregate
 	 *
-	 * @return NetworkAddressIterator
+	 * @return Traversable
 	 */
-	public function getIterator()
+	public function getIterator(): Traversable
 	{
 		return new NetworkAddressIterator($this);
 	}
@@ -590,7 +590,7 @@ abstract class NetworkAddress implements \IteratorAggregate, \Countable
 	 *
 	 * @return integer
 	 */
-	public function count()
+	public function count(): int
 	{
 		return $this->get_NetworkAddress_count();
 	}


### PR DESCRIPTION
This Pull Request is aimed at fixing issues between the Leth\IPAddress library and PHP 8. These problems were caused by changes in how return types are declared in PHP 8. The library worked fine with PHP 7, but when used with PHP 8, certain methods in the library triggered PHP Deprecated notices. These notices indicate that there might be problems with the outdated return types.

In PHP 8, stricter checks were introduced for return types, and some methods in the Leth\IPAddress library had return types that no longer matched what the corresponding interfaces expected. As a result, using the library with PHP 8 generated deprecation notices, warning about incompatible return types in specific methods.